### PR TITLE
BUGFIX: Tooltip crash after edit the layer

### DIFF
--- a/src/components/views/Viewer.js
+++ b/src/components/views/Viewer.js
@@ -193,7 +193,7 @@ function cleanJson(json) {
     delete result.layers[0].binary;
 
     // Avoid that views property appears in editor
-    delete result.views;
+    delete result.views[0].mapStyle;
   }
   return result;
 }

--- a/src/components/views/Viewer.js
+++ b/src/components/views/Viewer.js
@@ -196,7 +196,8 @@ function Viewer(props) {
 
   jsonConverter.configuration.functions.onDataError = () => {
     return (error) => {
-      if (error.message.includes('Unauthorized') || error.message.includes('Not Found')) {
+      debugger
+      if (error.message.includes('Unauthorized') || error.message.includes('Not Found') || error.message.includes('Unexpected token')) {
         setShowNotFoundScreen(true);
       }
     };

--- a/src/components/views/Viewer.js
+++ b/src/components/views/Viewer.js
@@ -157,9 +157,6 @@ async function parseConfig(query, username, type) {
       };
     }
 
-    // Set binary property
-    json.layers[0].binary = true;
-
     if (initialViewState) {
       json.initialViewState = {
         ...json.initialViewState,
@@ -177,7 +174,14 @@ async function parseConfig(query, username, type) {
     };
   }
 
+  addMandatoryProperties(json);
   return { json, ready };
+}
+
+function addMandatoryProperties(json) {
+  // Set binary property
+  json.layers[0].binary = true;
+  return json;
 }
 
 function cleanJson(json) {
@@ -187,6 +191,9 @@ function cleanJson(json) {
 
     // Avoid that binary prop appears in editor
     delete result.layers[0].binary;
+
+    // Avoid that views property appears in editor
+    delete result.views;
   }
   return result;
 }
@@ -299,6 +306,7 @@ function Viewer(props) {
 
   const onEditorChange = (jsonText) => {
     const tempJson = JSON.parse(jsonText);
+    addMandatoryProperties(tempJson);
     setJSONMap(tempJson);
   };
 


### PR DESCRIPTION
https://app.clubhouse.io/cartoteam/story/140560/tooltip-is-lost-when-changing-viz-configuration-of-tileset-when-opening-it-from-dashboard

Remove mapStyle in JsonEditor: https://app.clubhouse.io/cartoteam/story/140584/unsynced-basemap-selection-and-config-in-tileset-viewer